### PR TITLE
fix createJobTable failure when table name contains dot

### DIFF
--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -188,7 +188,7 @@ defaultDynamicJobTypes :: TableName
                        -> PGS.Query
                        -> AllJobTypes
 defaultDynamicJobTypes tname jobTypeSql = AJTSql $ \conn -> do
-  fmap (DL.map ((fromMaybe "(unknown)") . fromOnly)) $ PGS.query_ conn $ "select distinct(" <> jobTypeSql <> ") from " <> tname <> " order by 1 nulls last"
+  fmap (DL.map ((fromMaybe "(unknown)") . fromOnly)) $ PGS.query conn ("select distinct(" <> jobTypeSql <> ") from ? order by 1 nulls last") (Only tname)
 
 -- | This makes __two important assumptions__. First, this /assumes/ that jobs
 -- in your app are represented by a sum-type. For example:

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -42,7 +42,7 @@ createNotificationTrigger = "create or replace function ?() returns trigger as $
 
 createJobTable :: Connection -> TableName -> IO ()
 createJobTable conn tname = void $ do
-  let tnameTxt = PGS.fromIdentifier tname
+  let tnameTxt = getTnameTxt tname
   PGS.execute conn createJobTableQuery
     ( tname
     , PGS.Identifier $ "idx_" <> tnameTxt <> "_created_at"
@@ -66,5 +66,6 @@ createJobTable conn tname = void $ do
     , fnName
     )
   where
-    fnName = PGS.Identifier $ "notify_job_monitor_for_" <> PGS.fromIdentifier tname
-    trgName = PGS.Identifier $ "trg_notify_job_monitor_for_" <> PGS.fromIdentifier tname
+    fnName = PGS.Identifier $ "notify_job_monitor_for_" <> (getTnameTxt tname)
+    trgName = PGS.Identifier $ "trg_notify_job_monitor_for_" <> (getTnameTxt tname)
+    getTnameTxt (PGS.QualifiedIdentifier _ tname') = tname'

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -5,11 +5,12 @@ module OddJobs.Migrations
 where
 
 import Database.PostgreSQL.Simple as PGS
+import Database.PostgreSQL.Simple.Types as PGS
 import Data.Functor (void)
 import OddJobs.Types
 
-createJobTableQuery :: TableName -> Query
-createJobTableQuery tname = "CREATE TABLE " <> tname <>
+createJobTableQuery :: Query
+createJobTableQuery = "CREATE TABLE ?" <>
   "( id serial primary key" <>
   ", created_at timestamp with time zone default now() not null" <>
   ", updated_at timestamp with time zone default now() not null" <>
@@ -22,28 +23,48 @@ createJobTableQuery tname = "CREATE TABLE " <> tname <>
   ", locked_by text null" <>
   ", constraint incorrect_locking_info CHECK ((status <> 'locked' and locked_at is null and locked_by is null) or (status = 'locked' and locked_at is not null and locked_by is not null))" <>
   ");" <>
-  "create index idx_" <> tname <> "_created_at on " <> tname <> "(created_at);" <>
-  "create index idx_" <> tname <> "_updated_at on " <> tname <> "(updated_at);" <>
-  "create index idx_" <> tname <> "_locked_at on " <> tname <> "(locked_at);" <>
-  "create index idx_" <> tname <> "_locked_by on " <> tname <> "(locked_by);" <>
-  "create index idx_" <> tname <> "_status on " <> tname <> "(status);" <>
-  "create index idx_" <> tname <> "_run_at on " <> tname <> "(run_at);"
+  "create index ? on ?(created_at);" <>
+  "create index ? on ?(updated_at);" <>
+  "create index ? on ?(locked_at);" <>
+  "create index ? on ?(locked_by);" <>
+  "create index ? on ?(status);" <>
+  "create index ? on ?(run_at);"
 
-createNotificationTrigger :: TableName -> Query
-createNotificationTrigger tname = "create or replace function " <> fnName <> "() returns trigger as $$" <>
+createNotificationTrigger :: Query
+createNotificationTrigger = "create or replace function ?() returns trigger as $$" <>
   "begin \n" <>
-  "  perform pg_notify('" <> pgEventName tname <> "', \n" <>
+  "  perform pg_notify('?', \n" <>
   "    json_build_object('id', new.id, 'run_at', new.run_at, 'locked_at', new.locked_at)::text); \n" <>
   "  return new; \n" <>
   "end; \n" <>
   "$$ language plpgsql;" <>
-  "create trigger " <> trgName <> " after insert on " <> tname <> " for each row execute procedure " <> fnName <> "();"
-  where
-    fnName = "notify_job_monitor_for_" <> tname
-    trgName = "trg_notify_job_monitor_for_" <> tname
-
+  "create trigger ? after insert on ? for each row execute procedure ?();"
 
 createJobTable :: Connection -> TableName -> IO ()
 createJobTable conn tname = void $ do
-  PGS.execute_ conn (createJobTableQuery tname)
-  PGS.execute_ conn (createNotificationTrigger tname)
+  let tnameTxt = PGS.fromIdentifier tname
+  PGS.execute conn createJobTableQuery
+    ( tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_created_at"
+    , tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_updated_at"
+    , tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_locked_at"
+    , tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_locked_by"
+    , tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_status"
+    , tname
+    , PGS.Identifier $ "idx_" <> tnameTxt <> "_run_at"
+    , tname
+    )
+  PGS.execute conn createNotificationTrigger
+    ( fnName
+    , pgEventName tname
+    , trgName
+    , tname
+    , fnName
+    )
+  where
+    fnName = PGS.Identifier $ "notify_job_monitor_for_" <> PGS.fromIdentifier tname
+    trgName = PGS.Identifier $ "trg_notify_job_monitor_for_" <> PGS.fromIdentifier tname

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -7,6 +7,7 @@
 module OddJobs.Types where
 
 import Database.PostgreSQL.Simple as PGS
+import Database.PostgreSQL.Simple.Types as PGS
 import UnliftIO (MonadIO)
 import UnliftIO.Concurrent (threadDelay)
 import Data.Text.Conversions
@@ -33,10 +34,10 @@ import Control.Monad.Logger (LogLevel)
 -- myJobsTable :: TableName
 -- myJobsTable = "my_jobs"
 -- @
-type TableName = PGS.Query
+type TableName = PGS.Identifier
 
-pgEventName :: TableName -> Query
-pgEventName tname = "job_created_" <> tname
+pgEventName :: TableName -> PGS.Identifier
+pgEventName tname = PGS.Identifier $ "job_created_" <> PGS.fromIdentifier tname
 
 newtype Seconds = Seconds { unSeconds :: Int } deriving (Eq, Show, Ord, Num, Read)
 

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -24,7 +24,8 @@ import Lucid (Html(..))
 import Data.Pool (Pool)
 import Control.Monad.Logger (LogLevel)
 
--- | An alias for 'Query' type. Since this type has an instance of 'IsString'
+-- | An alias for 'Identifier' type, it is used for the job table name.
+-- Since this type has an instance of 'IsString',
 -- you do not need to do anything special to create a value for this type. Just
 -- ensure you have the @OverloadedStrings@ extention enabled. For example:
 --

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -24,7 +24,7 @@ import Lucid (Html(..))
 import Data.Pool (Pool)
 import Control.Monad.Logger (LogLevel)
 
--- | An alias for 'Identifier' type, it is used for the job table name.
+-- | An alias for 'QualifiedIdentifier' type, it is used for the job table name.
 -- Since this type has an instance of 'IsString',
 -- you do not need to do anything special to create a value for this type. Just
 -- ensure you have the @OverloadedStrings@ extention enabled. For example:
@@ -35,10 +35,11 @@ import Control.Monad.Logger (LogLevel)
 -- myJobsTable :: TableName
 -- myJobsTable = "my_jobs"
 -- @
-type TableName = PGS.Identifier
+type TableName = PGS.QualifiedIdentifier
 
 pgEventName :: TableName -> PGS.Identifier
-pgEventName tname = PGS.Identifier $ "job_created_" <> PGS.fromIdentifier tname
+pgEventName (PGS.QualifiedIdentifier Nothing tname) = PGS.Identifier $ "jobs_created_" <> tname
+pgEventName (PGS.QualifiedIdentifier (Just schema) tname) = PGS.Identifier $ "jobs_created_" <> schema <> "_" <> tname
 
 newtype Seconds = Seconds { unSeconds :: Int } deriving (Eq, Show, Ord, Num, Read)
 

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -24,7 +24,7 @@ import Lucid (Html(..))
 import Data.Pool (Pool)
 import Control.Monad.Logger (LogLevel)
 
--- | An alias for 'QualifiedIdentifier' type, it is used for the job table name.
+-- | An alias for 'QualifiedIdentifier' type. It is used for the job table name.
 -- Since this type has an instance of 'IsString',
 -- you do not need to do anything special to create a value for this type. Just
 -- ensure you have the @OverloadedStrings@ extention enabled. For example:
@@ -35,6 +35,16 @@ import Control.Monad.Logger (LogLevel)
 -- myJobsTable :: TableName
 -- myJobsTable = "my_jobs"
 -- @
+-- 
+-- This should also work for table names qualified by the schema name. For example:
+--
+-- @
+-- {-\# LANGUAGE OverloadedStrings \#-}
+--
+-- myJobsTable :: TableName
+-- myJobsTable = "odd_jobs.jobs"
+-- @
+
 type TableName = PGS.QualifiedIdentifier
 
 pgEventName :: TableName -> PGS.Identifier

--- a/src/OddJobs/Web.hs
+++ b/src/OddJobs/Web.hs
@@ -128,8 +128,8 @@ data Routes = Routes
 
 filterJobsQuery :: Config -> Filter -> (PGS.Query, [Action])
 filterJobsQuery Config{cfgTableName, cfgJobTypeSql} Filter{..} =
-  ( "SELECT " <> Job.concatJobDbColumns <> " FROM " <> cfgTableName <> whereClause <> " " <> (orderClause $ fromMaybe (OrdUpdatedAt, Desc) filterOrder) <> " " <> limitOffsetClause
-  , whereActions
+  ( "SELECT " <> Job.concatJobDbColumns <> " FROM ?" <> whereClause <> " " <> (orderClause $ fromMaybe (OrdUpdatedAt, Desc) filterOrder) <> " " <> limitOffsetClause
+  , (toRow $ Only cfgTableName) ++ whereActions
   )
   where
     orderClause (flt, dir) =


### PR DESCRIPTION
`createJobTable` fails when the table name contains a dot
for example `myschema.jobs`.

Fixes #52 