### PR TITLE
Skip creating new table if the table already exists

### DIFF
--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -38,7 +38,7 @@ createNotificationTrigger = "create or replace function ?() returns trigger as $
   "  return new; \n" <>
   "end; \n" <>
   "$$ language plpgsql;" <>
-  "create trigger ? after insert on ? for each row execute procedure ?();"
+  "create trigger if not exists ? after insert on ? for each row execute procedure ?();"
 
 createJobTable :: Connection -> TableName -> IO ()
 createJobTable conn tname = void $ do

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -10,7 +10,7 @@ import Data.Functor (void)
 import OddJobs.Types
 
 createJobTableQuery :: Query
-createJobTableQuery = "CREATE TABLE ?" <>
+createJobTableQuery = "CREATE TABLE ? IF NOT EXISTS ?" <>
   "( id serial primary key" <>
   ", created_at timestamp with time zone default now() not null" <>
   ", updated_at timestamp with time zone default now() not null" <>
@@ -45,6 +45,7 @@ createJobTable conn tname = void $ do
   let tnameTxt = getTnameTxt tname
   PGS.execute conn createJobTableQuery
     ( tname
+    , tname
     , PGS.Identifier $ "idx_" <> tnameTxt <> "_created_at"
     , tname
     , PGS.Identifier $ "idx_" <> tnameTxt <> "_updated_at"

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -10,7 +10,7 @@ import Data.Functor (void)
 import OddJobs.Types
 
 createJobTableQuery :: Query
-createJobTableQuery = "CREATE TABLE ? IF NOT EXISTS ?" <>
+createJobTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
   "( id serial primary key" <>
   ", created_at timestamp with time zone default now() not null" <>
   ", updated_at timestamp with time zone default now() not null" <>
@@ -45,7 +45,6 @@ createJobTable conn tname = void $ do
   let tnameTxt = getTnameTxt tname
   PGS.execute conn createJobTableQuery
     ( tname
-    , tname
     , PGS.Identifier $ "idx_" <> tnameTxt <> "_created_at"
     , tname
     , PGS.Identifier $ "idx_" <> tnameTxt <> "_updated_at"

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -23,12 +23,12 @@ createJobTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
   ", locked_by text null" <>
   ", constraint incorrect_locking_info CHECK ((status <> 'locked' and locked_at is null and locked_by is null) or (status = 'locked' and locked_at is not null and locked_by is not null))" <>
   ");" <>
-  "create index ? on ?(created_at);" <>
-  "create index ? on ?(updated_at);" <>
-  "create index ? on ?(locked_at);" <>
-  "create index ? on ?(locked_by);" <>
-  "create index ? on ?(status);" <>
-  "create index ? on ?(run_at);"
+  "create index if not exists ? on ?(created_at);" <>
+  "create index if not exists ? on ?(updated_at);" <>
+  "create index if not exists ? on ?(locked_at);" <>
+  "create index if not exists ? on ?(locked_by);" <>
+  "create index if not exists ? on ?(status);" <>
+  "create index if not exists ? on ?(run_at);"
 
 createNotificationTrigger :: Query
 createNotificationTrigger = "create or replace function ?() returns trigger as $$" <>

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -38,7 +38,7 @@ createNotificationTrigger = "create or replace function ?() returns trigger as $
   "  return new; \n" <>
   "end; \n" <>
   "$$ language plpgsql;" <>
-  "create trigger if not exists ? after insert on ? for each row execute procedure ?();"
+  "drop trigger if exists ?; create trigger ? after insert on ? for each row execute procedure ?();"
 
 createJobTable :: Connection -> TableName -> IO ()
 createJobTable conn tname = void $ do
@@ -61,6 +61,7 @@ createJobTable conn tname = void $ do
   PGS.execute conn createNotificationTrigger
     ( fnName
     , pgEventName tname
+    , trgName
     , trgName
     , tname
     , fnName

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -38,7 +38,8 @@ createNotificationTrigger = "create or replace function ?() returns trigger as $
   "  return new; \n" <>
   "end; \n" <>
   "$$ language plpgsql;" <>
-  "drop trigger if exists ?; create trigger ? after insert on ? for each row execute procedure ?();"
+  "drop trigger if exists ? on ?;" <>
+  "create trigger ? after insert on ? for each row execute procedure ?();"
 
 createJobTable :: Connection -> TableName -> IO ()
 createJobTable conn tname = void $ do
@@ -62,6 +63,7 @@ createJobTable conn tname = void $ do
     ( fnName
     , pgEventName tname
     , trgName
+    , tname
     , trgName
     , tname
     , fnName


### PR DESCRIPTION
When I try to use `createJobTable` to run the migration, it will raise an error saying 

```
 SqlError {sqlState = "42P07", sqlExecStatus = FatalError, sqlErrorMsg = "relation \"jobs\" already exists", sqlErrorDetail = "", sqlErrorHint = ""}
```

This PR is to skip creating new table if the table is already there