### PR TITLE
Add concurrency control based on job type

### DIFF
--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -118,6 +118,11 @@ data ConcurrencyControl
   -- | The maximum number of concurrent jobs that /this instance/ of the
   -- job-runner can execute.
   = MaxConcurrentJobs Int
+  -- | The maximum number of concurrent jobs that /this instance/ of the job
+  -- runner can execute for /each type/. If the job limit is reached for a
+  -- particular job type, new jobs with that type will /not/ be picked up by the
+  -- job runner, even if there are no jobs running with other types.
+  | MaxConcurrentJobsPerType Int
   -- | __Not recommended:__ Please do not use this in production unless you know
   -- what you're doing. No machine can support unlimited concurrency. If your
   -- jobs are doing anything worthwhile, running a sufficiently large number
@@ -134,6 +139,7 @@ data ConcurrencyControl
 instance Show ConcurrencyControl where
   show cc = case cc of
     MaxConcurrentJobs n -> "MaxConcurrentJobs " <> show n
+    MaxConcurrentJobsPerType n -> "MaxConcurrentJobsPerType " <> show n
     UnlimitedConcurrentJobs -> "UnlimitedConcurrentJobs"
     DynamicConcurrency _ -> "DynamicConcurrency (IO Bool)"
 


### PR DESCRIPTION
This is an important use case for us, since we have certain expensive jobs that shouldn't hog all the resources on the machine. This adds a new kind of ConcurrencyControl, that limits the number of jobs that can be simultaneously executed per job-type.

I tried to modify the code in such a way that polling is not made significantly more expensive by the existence of the new concurrency control - but there might be a slight decrease in performance, because the job type filter is filled from the list of all job types, which might result in a query. This could be fixed by making two polling queries: one which takes the filter, and one which doesn't.