### PR TITLE
Push failed jobs to end of the queue

### DIFF
--- a/src/OddJobs/Job.hs
+++ b/src/OddJobs/Job.hs
@@ -456,7 +456,7 @@ jobMonitor = do
 
 -- | Ref: 'jobPoller'
 jobPollingSql :: Query
-jobPollingSql = "update ? set status = ?, locked_at = ?, locked_by = ?, attempts=attempts+1 WHERE id in (select id from ? where (run_at<=? AND ((status in ?) OR (status = ? and locked_at<?))) ORDER BY run_at ASC LIMIT 1 FOR UPDATE) RETURNING id"
+jobPollingSql = "update ? set status = ?, locked_at = ?, locked_by = ?, attempts=attempts+1 WHERE id in (select id from ? where (run_at<=? AND ((status in ?) OR (status = ? and locked_at<?))) ORDER BY attempts ASC, run_at ASC LIMIT 1 FOR UPDATE) RETURNING id"
 
 waitForJobs :: (HasJobRunner m)
             => m ()


### PR DESCRIPTION
Order jobpollingsql by attempts first so that failed jobs go to end
of the queue.

The reason is that failed jobs are likely to fail again.
In our case we have some really heavy jobs that consume a lot
of resources, interspersed with lighter ones.
If one of the heavy job fails, it's better some other job
gets a chance to run first. Odd jobs can work on that heavy one again
when it's less busy (during night for example).