### PR TITLE
Extract UI related config params into a UIConfig type

### DIFF
--- a/examples/OddJobsCliExample.lhs
+++ b/examples/OddJobsCliExample.lhs
@@ -106,54 +106,6 @@ main = runCli CliBoth{..}
           let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
           defaultWebUI uiStartArgs $
             mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
-
-
--- main :: IO ()
--- main = do
---   dbPool <- createPool
---             (PGS.connectPostgreSQL "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")
---             PGS.close
---             1
---             10
---             8
---   tcache <- newTimeCache simpleTimeFormat
---   (tlogger, tloggerCleanup) <- newTimedFastLogger tcache (LogFileNoRotate "oddjobs.log" defaultBufSize)
---   let jobLogger = defaultTimedLogger tlogger (defaultLogStr defaultJobType)
---       cliStartJobRunner cfgOverrideFn = do
---         startJobRunner $
---           mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner cfgOverrideFn
-
---       cliStartWebUI uiStartArgs cfgOverrideFn = do
---         defaultWebUI uiStartArgs $
---           mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
-
---   runCli CliBoth{..}
-
-
-  -- do
-  -- -- a utility function provided by `OddJobs.ConfigBuilder` which ensures
-  -- -- that the DB pool is gracefully destroyed upon shutdown.
-  -- withConnectionPool (Left "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")$ \dbPool -> do
-
-  --   -- Boilerplate code to setup a TimedFastLogger (from the fast-logger library)
-  --   tcache <- newTimeCache simpleTimeFormat
-  --   withTimedFastLogger tcache (LogFileNoRotate "oddjobs.log" defaultBufSize) $ \logger -> do
-  --   -- withTimedFastLogger tcache (LogStdout defaultBufSize) $ \logger -> do
-
-  --     -- Using the default string-based logging provided by
-  --     -- `OddJobs.ConfigBuilder`. If you want to actually use
-  --     -- structured-logging you'll need to define your own logging function.
-  --     let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
-  --         cliStartJobRunner cfgOverrideFn = do
-  --           putStrLn "starting job runner"
-  --           startJobRunner $
-  --             mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner cfgOverrideFn
-  --         cliStartWebUI uiStartArgs cfgOverrideFn = defaultWebUI uiStartArgs $
-  --                                                   mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
-
-  --     jobLogger LevelInfo (LogText "about to start cli")
-  --     -- Finally, executing the callback function that was passed to me...
-  --     runCli CliBoth{..}
 \end{code}
 
 === 6. Compile and start the Odd Jobs runner

--- a/examples/OddJobsCliExample.lhs
+++ b/examples/OddJobsCliExample.lhs
@@ -21,18 +21,20 @@ Ideally, this module should be compiled into a separate executable and should de
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module OddJobsCliExample where
 
-import OddJobs.Job (Job(..),  ConcurrencyControl(..), Config(..), throwParsePayload)
-import OddJobs.ConfigBuilder (mkConfig, withConnectionPool, defaultTimedLogger, defaultLogStr, defaultJobType)
-import OddJobs.Cli (defaultMain)
+import OddJobs.Job (Job(..),  ConcurrencyControl(..), Config(..), throwParsePayload, startJobRunner, LogLevel(..), LogEvent(..))
+import OddJobs.ConfigBuilder (mkConfig, withConnectionPool, defaultTimedLogger, defaultLogStr, defaultJobType, mkUIConfig)
+import OddJobs.Cli (runCli, defaultWebUI, CliType(..))
 
 -- Note: It is not necessary to use fast-logger. You can use any logging library
 -- that can give you a logging function in the IO monad.
-import System.Log.FastLogger(withTimedFastLogger, LogType'(..), defaultBufSize)
+import System.Log.FastLogger(withTimedFastLogger, LogType'(..), defaultBufSize, newTimedFastLogger)
 import System.Log.FastLogger.Date (newTimeCache, simpleTimeFormat)
-
+import Database.PostgreSQL.Simple as PGS
+import Data.Pool
 import Data.Text (Text)
 import Data.Aeson as Aeson
 import GHC.Generics
@@ -87,32 +89,71 @@ myJobRunner job = do
 
 \begin{code}
 main :: IO ()
-main = do
-  defaultMain startJobMonitor
+main = runCli CliBoth{..}
   where
-    -- A callback-within-callback function. If the commands-line args contain a
-    -- `start` command, this function will be called. Once this function has
-    -- constructed the 'Config' (which requires setting up a logging function,
-    -- and a DB pool) it needs to execute the `callback` function that is passed
-    -- to it.
-    startJobMonitor callback =
-
-      -- a utility function provided by `OddJobs.ConfigBuilder` which ensures
-      -- that the DB pool is gracefully destroyed upon shutdown.
+    cliStartJobRunner cfgOverrideFn = do
       withConnectionPool (Left "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")$ \dbPool -> do
-
-        -- Boilerplate code to setup a TimedFastLogger (from the fast-logger library)
         tcache <- newTimeCache simpleTimeFormat
         withTimedFastLogger tcache (LogFileNoRotate "oddjobs.log" defaultBufSize) $ \logger -> do
-
-          -- Using the default string-based logging provided by
-          -- `OddJobs.ConfigBuilder`. If you want to actually use
-          -- structured-logging you'll need to define your own logging function.
           let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
-              cfg = mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner Prelude.id
+          startJobRunner $
+            mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner cfgOverrideFn
 
-          -- Finally, executing the callback function that was passed to me...
-          callback cfg
+    cliStartWebUI uiStartArgs cfgOverrideFn = do
+      withConnectionPool (Left "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")$ \dbPool -> do
+        tcache <- newTimeCache simpleTimeFormat
+        withTimedFastLogger tcache (LogFileNoRotate "oddjobs-web.log" defaultBufSize) $ \logger -> do
+          let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
+          defaultWebUI uiStartArgs $
+            mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
+
+
+-- main :: IO ()
+-- main = do
+--   dbPool <- createPool
+--             (PGS.connectPostgreSQL "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")
+--             PGS.close
+--             1
+--             10
+--             8
+--   tcache <- newTimeCache simpleTimeFormat
+--   (tlogger, tloggerCleanup) <- newTimedFastLogger tcache (LogFileNoRotate "oddjobs.log" defaultBufSize)
+--   let jobLogger = defaultTimedLogger tlogger (defaultLogStr defaultJobType)
+--       cliStartJobRunner cfgOverrideFn = do
+--         startJobRunner $
+--           mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner cfgOverrideFn
+
+--       cliStartWebUI uiStartArgs cfgOverrideFn = do
+--         defaultWebUI uiStartArgs $
+--           mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
+
+--   runCli CliBoth{..}
+
+
+  -- do
+  -- -- a utility function provided by `OddJobs.ConfigBuilder` which ensures
+  -- -- that the DB pool is gracefully destroyed upon shutdown.
+  -- withConnectionPool (Left "dbname=jobs_test user=jobs_test password=jobs_test host=localhost")$ \dbPool -> do
+
+  --   -- Boilerplate code to setup a TimedFastLogger (from the fast-logger library)
+  --   tcache <- newTimeCache simpleTimeFormat
+  --   withTimedFastLogger tcache (LogFileNoRotate "oddjobs.log" defaultBufSize) $ \logger -> do
+  --   -- withTimedFastLogger tcache (LogStdout defaultBufSize) $ \logger -> do
+
+  --     -- Using the default string-based logging provided by
+  --     -- `OddJobs.ConfigBuilder`. If you want to actually use
+  --     -- structured-logging you'll need to define your own logging function.
+  --     let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
+  --         cliStartJobRunner cfgOverrideFn = do
+  --           putStrLn "starting job runner"
+  --           startJobRunner $
+  --             mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner cfgOverrideFn
+  --         cliStartWebUI uiStartArgs cfgOverrideFn = defaultWebUI uiStartArgs $
+  --                                                   mkUIConfig jobLogger "jobs" dbPool cfgOverrideFn
+
+  --     jobLogger LevelInfo (LogText "about to start cli")
+  --     -- Finally, executing the callback function that was passed to me...
+  --     runCli CliBoth{..}
 \end{code}
 
 === 6. Compile and start the Odd Jobs runner

--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6677b61240c930d793f07c90cd9dc719586179d99bdc7dc7b3dbe9a32d9a2afa
+-- hash: 81dabf5fa65d737ec98a4f07762968283cccc36292941ff7fff10a9a398e84b0
 
 name:           odd-jobs
 version:        0.2.2
@@ -67,7 +67,7 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
-    , direct-daemonize
+    , daemons
     , directory
     , either
     , fast-logger
@@ -121,7 +121,7 @@ executable devel
       aeson
     , base >=4.7 && <5
     , bytestring
-    , direct-daemonize
+    , daemons
     , directory
     , either
     , fast-logger
@@ -168,7 +168,7 @@ executable odd-jobs-cli-example
       aeson
     , base >=4.7 && <5
     , bytestring
-    , direct-daemonize
+    , daemons
     , directory
     , either
     , fast-logger
@@ -226,7 +226,7 @@ test-suite jobrunner
     , base >=4.7 && <5
     , bytestring
     , containers
-    , direct-daemonize
+    , daemons
     , directory
     , either
     , fast-logger

--- a/package.yaml
+++ b/package.yaml
@@ -85,7 +85,7 @@ dependencies:
   - warp
   - unordered-containers
   - optparse-applicative
-  - direct-daemonize
+  - daemons
   - filepath
   - directory
   - generic-deriving

--- a/src/OddJobs/Cli.hs
+++ b/src/OddJobs/Cli.hs
@@ -122,19 +122,6 @@ defaultStartCommand CommonStartArgs{..} mUIArgs cliType = do
       coreStartupFn
     True -> do
       Daemon.runDetached (Just startPidFile) (Daemon.ToFile "/tmp/oddjobs.out") coreStartupFn
-      -- (Dir.doesPathExist startPidFile) >>= \case
-      --   True -> do
-      --     putStrLn $
-      --       "PID file (i.e. " <> startPidFile <> ")already exists. Please check if " <> progName <> " is still running in the background." <>
-      --       " If not, you can safely delete this file and start " <> progName <> " again."
-      --     Exit.exitWith (Exit.ExitFailure 1)
-      --   False -> do
-      --     runDetached (Just startPidFile) (ToFile "/tmp/oddjobs.out") $ do
-      --       finally coreStartupFn (Dir.removeFile startPidFile)
-            -- pid <- getProcessID
-            -- bracket_ (writeFile startPidFile (show pid)) (Dir.removeFile startPidFile) $ do
-            --   putStrLn $ "Started " <> progName <> " in background with PID=" <> show pid <> ". PID written to " <> startPidFile
-            --   coreStartupFn
   where
     uiArgs = fromJustNote "Please specify Web UI Startup Args" $ traceShowId mUIArgs
     coreStartupFn =
@@ -150,16 +137,6 @@ defaultStartCommand CommonStartArgs{..} mUIArgs cliType = do
             traceM "CliBoth inside withAsync"
             cliStartJobRunner Prelude.id
             traceM "CliBoth end"
-
--- daemonOptions :: DaemonOptions
--- daemonOptions = DaemonOptions
---   { daemonShouldChangeDirectory = False
---   , daemonShouldCloseStandardStreams = True
---   , daemonShouldIgnoreSignals = True
---   , daemonUserToChangeTo = Nothing
---   , daemonGroupToChangeTo = Nothing
---   }
-
 
 defaultWebUI :: UIStartArgs
              -> UIConfig

--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -73,23 +73,25 @@ mkConfig logger tname dbpool ccControl jrunner configOverridesFn =
 
 
 mkUIConfig :: (LogLevel -> LogEvent -> IO ())
-           -- ^ "Structured logging" function. Ref: 'cfgLogger'
+           -- ^ "Structured logging" function. Ref: 'uicfgLogger'
            -> TableName
-           -- ^ DB table which holds your jobs. Ref: 'cfgTableName'
+           -- ^ DB table which holds your jobs. Ref: 'uicfgTableName'
            -> Pool Connection
-           -- ^ The actual "job runner" which contains your application code. Ref: 'cfgJobRunner'
+           -- ^ DB connection-pool to be used by web UI. Ref: 'uicfgDbPool'
            -> (UIConfig -> UIConfig)
-           -- ^ A function that allows you to modify the \"interim config\". The
-           -- \"interim config\" will cotain a bunch of in-built default config
-           -- params, along with the config params that you\'ve just provided
-           -- (i.e. logging function, table name, DB pool, etc). You can use this
-           -- function to override values in the \"interim config\". If you do not
-           -- wish to modify the \"interim config\" just pass 'Prelude.id' as an
-           -- argument to this parameter. __Note:__ it is strongly recommended
-           -- that you __do not__ modify the generated 'Config' outside of this
-           -- function, unless you know what you're doing.
+           -- ^ A function that allows you to modify the \"interim UI config\".
+           -- The \"interim config\" will cotain a bunch of in-built default
+           -- config params, along with the config params that you\'ve just
+           -- provided (i.e. logging function, table name, DB pool, etc). You
+           -- can use this function to override values in the \"interim UI
+           -- config\". If you do not wish to modify the \"interim UI config\"
+           -- just pass 'Prelude.id' as an argument to this parameter. __Note:__
+           -- it is strongly recommended that you __do not__ modify the
+           -- generated 'Config' outside of this function, unless you know what
+           -- you're doing.
            -> UIConfig
-           -- ^ The final 'Config' that can be used to start various job-runners
+           -- ^ The final 'UIConfig' that needs to be passed to
+           -- 'OddJobs.Endpoint.mkEnv' and 'OddJobs.Cli.defaultWebUI'
 mkUIConfig logger tname dbpool configOverridesFn =
   let cfg = configOverridesFn $ UIConfig
             { uicfgLogger = logger

--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -66,14 +66,42 @@ mkConfig logger tname dbpool ccControl jrunner configOverridesFn =
             , cfgTableName = tname
             , cfgOnJobTimeout = (const $ pure ())
             , cfgConcurrencyControl = ccControl
-            , cfgPidFile = Nothing
             , cfgJobType = defaultJobType
             , cfgDefaultJobTimeout = Seconds 600
-            , cfgJobToHtml = defaultJobToHtml (cfgJobType cfg)
-            , cfgAllJobTypes = (defaultDynamicJobTypes (cfgTableName cfg) (cfgJobTypeSql cfg))
-            , cfgJobTypeSql = defaultJobTypeSql
             }
   in cfg
+
+
+mkUIConfig :: (LogLevel -> LogEvent -> IO ())
+           -- ^ "Structured logging" function. Ref: 'cfgLogger'
+           -> TableName
+           -- ^ DB table which holds your jobs. Ref: 'cfgTableName'
+           -> Pool Connection
+           -- ^ The actual "job runner" which contains your application code. Ref: 'cfgJobRunner'
+           -> (UIConfig -> UIConfig)
+           -- ^ A function that allows you to modify the \"interim config\". The
+           -- \"interim config\" will cotain a bunch of in-built default config
+           -- params, along with the config params that you\'ve just provided
+           -- (i.e. logging function, table name, DB pool, etc). You can use this
+           -- function to override values in the \"interim config\". If you do not
+           -- wish to modify the \"interim config\" just pass 'Prelude.id' as an
+           -- argument to this parameter. __Note:__ it is strongly recommended
+           -- that you __do not__ modify the generated 'Config' outside of this
+           -- function, unless you know what you're doing.
+           -> UIConfig
+           -- ^ The final 'Config' that can be used to start various job-runners
+mkUIConfig logger tname dbpool configOverridesFn =
+  let cfg = configOverridesFn $ UIConfig
+            { uicfgLogger = logger
+            , uicfgDbPool = dbpool
+            , uicfgTableName = tname
+            , uicfgJobType = defaultJobType
+            , uicfgJobToHtml = defaultJobsToHtml (uicfgJobType cfg)
+            , uicfgAllJobTypes = (defaultDynamicJobTypes (uicfgTableName cfg) (uicfgJobTypeSql cfg))
+            , uicfgJobTypeSql = defaultJobTypeSql
+            }
+  in cfg
+
 
 
 
@@ -109,28 +137,30 @@ defaultLogStr jobTypeFn logLevel logEvent =
       LogText t ->
         toLogStr t
 
+defaultJobsToHtml :: (Job -> Text)
+                  -> [Job]
+                  -> IO [Html ()]
+defaultJobsToHtml jobType js = pure $ DL.map (defaultJobToHtml jobType) js
+
+
 defaultJobToHtml :: (Job -> Text)
-                 -> [Job]
-                 -> IO [Html ()]
-defaultJobToHtml jobType js =
-  pure $ DL.map jobToHtml js
-  where
-    jobToHtml :: Job -> Html ()
-    jobToHtml j = do
-      div_ [ class_ "job" ] $ do
-        div_ [ class_ "job-type" ] $ do
-          toHtml $ jobType j
-        div_ [ class_ "job-payload" ] $ do
-          defaultPayloadToHtml $ defaultJobContent $ jobPayload j
-        case jobLastError j of
-          Nothing -> mempty
-          Just e -> do
-            div_ [ class_ "job-error collapsed" ] $ do
-              a_ [ href_ "javascript: void(0);", onclick_ "toggleError(this)" ] $ do
-                span_ [ class_ "badge badge-secondary error-expand" ] "+ Last error"
-                span_ [ class_ "badge badge-secondary error-collapse d-none" ] "- Last error"
-              " "
-              defaultErrorToHtml e
+                 -> Job
+                 -> Html ()
+defaultJobToHtml jobType j =
+  div_ [ class_ "job" ] $ do
+    div_ [ class_ "job-type" ] $ do
+      toHtml $ jobType j
+    div_ [ class_ "job-payload" ] $ do
+      defaultPayloadToHtml $ defaultJobContent $ jobPayload j
+    case jobLastError j of
+      Nothing -> mempty
+      Just e -> do
+        div_ [ class_ "job-error collapsed" ] $ do
+          a_ [ href_ "javascript: void(0);", onclick_ "toggleError(this)" ] $ do
+            span_ [ class_ "badge badge-secondary error-expand" ] "+ Last error"
+            span_ [ class_ "badge badge-secondary error-collapse d-none" ] "- Last error"
+          " "
+          defaultErrorToHtml e
 
 
 defaultErrorToHtml :: Value -> Html ()

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -38,6 +38,7 @@ createNotificationTrigger = "create or replace function ?() returns trigger as $
   "  return new; \n" <>
   "end; \n" <>
   "$$ language plpgsql;" <>
+  "drop trigger if exists ? on ?;" <>
   "create trigger ? after insert on ? for each row execute procedure ?();"
 
 createJobTable :: Connection -> TableName -> IO ()
@@ -61,6 +62,8 @@ createJobTable conn tname = void $ do
   PGS.execute conn createNotificationTrigger
     ( fnName
     , pgEventName tname
+    , trgName
+    , tname
     , trgName
     , tname
     , fnName

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -342,15 +342,17 @@ data UIConfig = UIConfig
     -- created by the 'OddJobs.Migrations.createJobTable' function.
     uicfgTableName :: TableName
 
-    -- | The DB connection-pool to use for the job-runner. __Note:__ in case
-    -- your jobs require a DB connection, please create a separate
-    -- connection-pool for them. This pool will be used ONLY for monitoring jobs
-    -- and changing their status. We need to have __at least 4 connections__ in
-    -- this connection-pool for the job-runner to work as expected.
+    -- | The DB connection-pool to use for the web UI. __Note:__ the same DB
+    -- pool used by your job-runner can be passed here if it has a sufficient
+    -- number of connections to satisfy both use-scases. Else create a separate
+    -- DB pool to be used only by the web UI (this DB pool can have just 1-3
+    -- connection, because __typically__ the web UI doesn't serve too many
+    -- concurrent user in most real-life cases)
   , uicfgDbPool :: Pool Connection
 
     -- | How to extract the "job type" from a 'Job'. If you are overriding this,
-    -- please consider overriding 'cfgJobTypeSql' as well. Related:
+    -- please consider overriding 'cfgJobTypeSql' as well. __Note:__ Usually
+    -- 'cfgJobType' and 'uicfgJobType' would use the same value. Related:
     -- 'OddJobs.ConfigBuilder.defaultJobType'
   , uicfgJobType :: Job -> Text
 
@@ -359,7 +361,7 @@ data UIConfig = UIConfig
     -- directly in SQL (because transferrring the entire @payload@ column to
     -- Haskell, and then parsing it into JSON, and then applying the
     -- 'cfgJobType' function on it would be too inefficient). Ref:
-    -- 'OddJobs.ConfigBuilder.defaultJobTypeSql' and 'cfgJobType'
+    -- 'OddJobs.ConfigBuilder.defaultJobTypeSql' and 'uicfgJobType'
   , uicfgJobTypeSql :: PGS.Query
 
     -- | How to convert a list of 'Job's to a list of HTML fragments. This is

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -315,7 +315,7 @@ data Config = Config
   -- | File to store the PID of the job-runner process. This is used only when
   -- invoking the job-runner as an independent background deemon (the usual mode
   -- of deployment).
-  , cfgPidFile :: Maybe FilePath
+  -- , cfgPidFile :: Maybe FilePath
 
   -- | A "structured logging" function that __you__ need to provide. The
   -- @odd-jobs@ library does NOT use the standard logging interface provided by
@@ -331,17 +331,36 @@ data Config = Config
   -- 'OddJobs.ConfigBuilder.defaultJobType'
   , cfgJobType :: Job -> Text
 
+    -- | How long can a job run after which it is considered to be "crashed" and
+    -- picked up for execution again
+  , cfgDefaultJobTimeout :: Seconds
+  }
+
+
+data UIConfig = UIConfig
+  { -- | The DB table which holds your jobs. Please note, this should have been
+    -- created by the 'OddJobs.Migrations.createJobTable' function.
+    uicfgTableName :: TableName
+
+    -- | The DB connection-pool to use for the job-runner. __Note:__ in case
+    -- your jobs require a DB connection, please create a separate
+    -- connection-pool for them. This pool will be used ONLY for monitoring jobs
+    -- and changing their status. We need to have __at least 4 connections__ in
+    -- this connection-pool for the job-runner to work as expected.
+  , uicfgDbPool :: Pool Connection
+
+    -- | How to extract the "job type" from a 'Job'. If you are overriding this,
+    -- please consider overriding 'cfgJobTypeSql' as well. Related:
+    -- 'OddJobs.ConfigBuilder.defaultJobType'
+  , uicfgJobType :: Job -> Text
+
     -- | How to extract the \"job type\" directly in SQL. There are many places,
     -- especially in the web\/admin UI, where we need to know a job's type
     -- directly in SQL (because transferrring the entire @payload@ column to
     -- Haskell, and then parsing it into JSON, and then applying the
     -- 'cfgJobType' function on it would be too inefficient). Ref:
     -- 'OddJobs.ConfigBuilder.defaultJobTypeSql' and 'cfgJobType'
-  , cfgJobTypeSql :: PGS.Query
-
-    -- | How long can a job run after which it is considered to be "crashed" and
-    -- picked up for execution again
-  , cfgDefaultJobTimeout :: Seconds
+  , uicfgJobTypeSql :: PGS.Query
 
     -- | How to convert a list of 'Job's to a list of HTML fragments. This is
     -- used in the Web\/Admin UI. This function accepts a /list/ of jobs and
@@ -349,12 +368,21 @@ data Config = Config
     -- another table to fetch some metadata (eg. convert a primary-key to a
     -- human-readable name), you can do it efficiently instead of resulting in
     -- an N+1 SQL bug. Ref: 'defaultJobToHtml'
-  , cfgJobToHtml :: [Job] -> IO [Html ()]
+  , uicfgJobToHtml :: [Job] -> IO [Html ()]
 
     -- | How to get a list of all known job-types? This is used by the
     -- Web\/Admin UI to power the \"filter by job-type\" functionality. The
     -- default value for this is 'OddJobs.ConfigBuilder.defaultDynamicJobTypes'
     -- which does a @SELECT DISTINCT payload ->> ...@ to get a list of job-types
     -- directly from the DB.
-  , cfgAllJobTypes :: AllJobTypes
+  , uicfgAllJobTypes :: AllJobTypes
+
+    -- | A "structured logging" function that __you__ need to provide. The
+    -- @odd-jobs@ library does NOT use the standard logging interface provided by
+    -- 'monad-logger' on purpose. Also look at 'cfgJobType' and 'defaultLogStr'
+    --
+    -- __Note:__ Please take a look at the section on [structured
+    -- logging](https://www.haskelltutorials.com/odd-jobs/guide.html#structured-logging)
+    -- to find out how to use this to log in JSON.
+  , uicfgLogger :: LogLevel -> LogEvent -> IO ()
   }

--- a/src/OddJobs/Web.hs
+++ b/src/OddJobs/Web.hs
@@ -126,10 +126,10 @@ data Routes = Routes
   }
 
 
-filterJobsQuery :: Config -> Filter -> (PGS.Query, [Action])
-filterJobsQuery Config{cfgTableName, cfgJobTypeSql} Filter{..} =
+filterJobsQuery :: UIConfig -> Filter -> (PGS.Query, [Action])
+filterJobsQuery UIConfig{uicfgTableName, uicfgJobTypeSql} Filter{..} =
   ( "SELECT " <> Job.concatJobDbColumns <> " FROM ?" <> whereClause <> " " <> (orderClause $ fromMaybe (OrdUpdatedAt, Desc) filterOrder) <> " " <> limitOffsetClause
-  , (toRow $ Only cfgTableName) ++ whereActions
+  , (toRow $ Only uicfgTableName) ++ whereActions
   )
   where
     orderClause (flt, dir) =
@@ -172,7 +172,7 @@ filterJobsQuery Config{cfgTableName, cfgJobTypeSql} Filter{..} =
     jobTypeClause = case filterJobTypes of
       [] -> Nothing
       xs ->
-        let qFragment = "(" <> cfgJobTypeSql <> ")=?"
+        let qFragment = "(" <> uicfgJobTypeSql <> ")=?"
             build ys (q, vs) = case ys of
               [] -> (q, vs)
               (y:[]) -> (qFragment <> q, (toField y):vs)
@@ -192,12 +192,12 @@ filterJobsQuery Config{cfgTableName, cfgJobTypeSql} Filter{..} =
 
     -- orderClause = _
 
-filterJobs :: Config -> Connection -> Filter -> IO [Job]
+filterJobs :: UIConfig -> Connection -> Filter -> IO [Job]
 filterJobs cfg conn f = do
   let (q, queryArgs) = filterJobsQuery cfg f
   PGS.query conn q queryArgs
 
-countJobs :: Config -> Connection -> Filter -> IO Int
+countJobs :: UIConfig -> Connection -> Filter -> IO Int
 countJobs cfg conn f = do
   let (q, queryArgs) = filterJobsQuery cfg f
       finalqry = "SELECT count(*) FROM (" <> q <> ") a"

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,8 @@ packages:
 #
 extra-deps:
   - timing-convenience-0.1@sha256:7ff807a9a9e5596f2b18d45c5a01aefb91d4a98f6a1008d183b5c550f68f7cb7,2092
-  - direct-daemonize-3.1@sha256:f33505932b8613267cd8ad2d51470af2c5708d750ddf55a5dd38292f04962dcc,1630
+  - daemons-0.3.0@sha256:356edaf06a8cf5e9f19685f9ce793ad6d2b6bce2e55379f6b2aff1b0c07a633f,3178
+
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
### Problem

1. `Config{..}` type was mixing up config params required for the job-runner along with the config params required for the web-UI.
2. There are cases where we want to start job-runners independently of the web-ui (typically you will only have one instance of the web-ui, whereas you may have multiple instances of the job-runner on different machines)
3. The mixing-up of these two concerns in the `Config{..}` type forces one to define unnecessary config params if only the web-ui needs to be started or only the job-runner needs to be started

#### Sub-problem

- The callback-within-callback style of `OddJobs.Cli` is very confusing. It was confusing even for me when I wanted to write a custom CLI for some purpose.

### Solution

1. Introduced `Types.UIConfig{..}`
2. Introduced `Cli.CliType` that allows one to easily start only the job-runner, only the web-ui, or both.
3. `OddJobs.Cli` parses the command-line and builds a `Config -> Config` (or `UIConfig -> UIConfig`) function that overrides the default config based on command-line arguments. This function can be passed to `mkConfig` or `mkUIConfig`. This avoid the "callback-withing-callback" style to some extent.
