### PR TITLE
Create temporary DB when testing instead of using local DB

### DIFF
--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6677b61240c930d793f07c90cd9dc719586179d99bdc7dc7b3dbe9a32d9a2afa
+-- hash: c5d572d202080362fc15306f8d59e7b86a6755ba988d1d00d20a93291edd70e1
 
 name:           odd-jobs
 version:        0.2.2
@@ -260,6 +260,7 @@ test-suite jobrunner
     , text-conversions
     , time
     , timing-convenience
+    , tmp-postgres
     , unix
     , unliftio
     , unliftio-core

--- a/package.yaml
+++ b/package.yaml
@@ -39,11 +39,11 @@ extra-source-files:
 - assets/odd-jobs-color-logo.png
 
 
-ghc-options: 
-  - -Wall 
-  - -fno-warn-orphans 
-  - -fno-warn-unused-imports 
-  - -fno-warn-dodgy-exports 
+ghc-options:
+  - -Wall
+  - -fno-warn-orphans
+  - -fno-warn-unused-imports
+  - -fno-warn-dodgy-exports
   - -Werror=missing-fields
   - -Werror=incomplete-patterns
 
@@ -149,3 +149,4 @@ tests:
       - lifted-base
       - lifted-async
       - containers
+      - tmp-postgres


### PR DESCRIPTION
## Description

To run the tests, a local Postgres instance must be running. This PR removes that requirement. 
Instead, it creates a temporary database (using the `tmp-postgres` library) and uses it to run the tests. Hopefully it makes the tests easier to run locally and more reproducible.

## Running the tests

### Stack
`stack test` succeeds locally.

### CI workflow

Unfortunately, the CI workflow fails because `initdb` is not in path. Not sure how to fix it (all my attempts at adding `initdb` to PATH have failed).