### PR TITLE
Make retry backoff configurable

### DIFF
--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -69,6 +69,7 @@ mkConfig logger tname dbpool ccControl jrunner configOverridesFn =
             , cfgJobType = defaultJobType
             , cfgDefaultJobTimeout = Seconds 600
             , cfgDeleteSuccessfulJobs = True
+            , cfgDefaultRetryBackoff = \attempts -> pure $ Seconds $ 2 ^ attempts
             }
   in cfg
 

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -337,6 +337,14 @@ data Config = Config
 
     -- | Should successful jobs be deleted from the queue to save on table space?
   , cfgDeleteSuccessfulJobs :: Bool
+
+    -- | How far into the future should jobs which can be retried be queued for?
+    --
+    -- The 'Int' argument is the number of times the job has been attepted. It will
+    -- always be at least 1, since the job will have to have started at least once
+    -- in order to fail and be retried. The default implementation is an exponential
+    -- backoff of @'Seconds' $ 2 ^ 'jobAttempts'@.
+  , cfgDefaultRetryBackoff :: Int -> IO Seconds
   }
 
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -81,6 +81,7 @@ tests appPool jobPool = testGroup "All tests"
                              , testGracefulShutdown appPool jobPool
                              , testJobErrHandler appPool jobPool
                              , testPushFailedJobEndQueue jobPool
+                             , testRetryBackoff appPool jobPool
                              ]
   -- , testGroup "property tests" [ testEverything appPool jobPool
   --                              -- , propFilterJobs appPool jobPool
@@ -355,6 +356,35 @@ testJobErrHandler appPool jobPool = testCase "job error handler" $ do
         delaySeconds (Job.defaultPollingInterval * 3)
       readMVar mvar1 >>= assertEqual "Error Handler 1 doesn't seem to have run" True
       readMVar mvar2 >>= assertEqual "Error Handler 2 doesn't seem to have run" True
+
+testRetryBackoff appPool jobPool = testCase "retry backoff" $ do
+  withRandomTable jobPool $ \tname -> do
+    withNamedJobMonitor tname jobPool modifyRetryBackoff $ \logRef -> do
+      Pool.withResource appPool $ \conn -> do
+        jobQueueTime <- getCurrentTime
+        Job{jobId} <- Job.createJob conn tname (PayloadAlwaysFail 0)
+        delaySeconds (2 * Job.defaultPollingInterval)
+
+        let assertBackedOff = do
+              job@Job{jobAttempts, jobStatus, jobRunAt} <- ensureJobId conn tname jobId
+              assertEqual "Exepcting job to be in Retry status" Job.Retry jobStatus
+              assertBool "Expecting job runAt to be in the future"
+                (jobRunAt >= addUTCTime (fromIntegral $ unSeconds $ backoff jobAttempts) jobQueueTime)
+
+        assertBackedOff
+
+        -- Run it for another attempt and check the backoff scales
+        job <- ensureJobId conn tname jobId
+        Job.saveJobIO conn tname (job {jobRunAt = jobQueueTime})
+        delaySeconds (2 * Job.defaultPollingInterval)
+
+        assertBackedOff
+  where
+
+    backoff attempts = Seconds $ 300 * attempts
+
+    modifyRetryBackoff cfg
+      = cfg { Job.cfgDefaultRetryBackoff = pure . backoff }
 
 data JobEvent = JobStart
               | JobRetry


### PR DESCRIPTION
The default retry backoff isn't too useful for us, so I thought it would be good to make it a configuration option. The default backoff behaviour is unchanged. The configuration lets the user decide on their own backoff strategy with possible side-effects.