### PR TITLE
Add ability to kill ongoing job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.3
 + Upgrade resource pool
++ Add ability to kill jobs
 
 ## 0.2.2
 

--- a/examples/OddJobsCliExample.lhs
+++ b/examples/OddJobsCliExample.lhs
@@ -72,11 +72,11 @@ In this example, the core job-runner function is in the `IO` monad. In all proba
 myJobRunner :: Job -> IO ()
 myJobRunner job = do
   throwParsePayload job >>= \case
-    SendWelcomeEmail _userId -> do
+    SendWelcomeEmail userId -> do
       putStrLn $ "This should call the function that actually sends the welcome email. " <>
         "\nWe are purposely waiting 60 seconds before completing this job so that graceful shutdown can be demonstrated."
       delaySeconds (Seconds 60)
-      putStrLn "60 second wait is now over..."
+      putStrLn $ "SendWelcomeEmail to user: " <> show userId <> " complete (60 second wait is now over...)"
     SendPasswordResetEmail _tkn ->
       putStrLn "This should call the function that actually sends the password-reset email"
     SetupSampleData _userId -> do

--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -76,7 +76,6 @@ library
     , base >=4.7 && <5
     , bytestring
     , containers
-    , daemons
     , directory
     , either
     , fast-logger
@@ -140,7 +139,6 @@ executable devel
     , base >=4.7 && <5
     , bytestring
     , containers
-    , daemons
     , directory
     , either
     , fast-logger

--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -75,6 +75,8 @@ library
     , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
+    , containers
+    , daemons
     , directory
     , either
     , fast-logger
@@ -137,6 +139,8 @@ executable devel
     , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
+    , containers
+    , daemons
     , directory
     , either
     , fast-logger

--- a/package.yaml
+++ b/package.yaml
@@ -85,6 +85,7 @@ dependencies:
   - servant-server
   - servant-lucid
   - warp
+  - containers
   - unordered-containers
   - optparse-applicative
   - filepath
@@ -149,4 +150,3 @@ tests:
       - mmorph
       - lifted-base
       - lifted-async
-      - containers

--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -144,6 +144,10 @@ defaultLogStr jobTypeFn logLevel logEvent =
       LogJobTimeout j@Job{jobLockedAt, jobLockedBy} ->
         "Timeout | " <> jobToLogStr j <> " | lockedBy=" <> toLogStr (maybe  "unknown" unJobRunnerName jobLockedBy) <>
         " lockedAt=" <> toLogStr (maybe "unknown" show jobLockedAt)
+      LogKillJobSuccess j ->
+        "Kill Job Success | " <> jobToLogStr j
+      LogKillJobFailed j ->
+        "Kill Job Failed | " <> jobToLogStr j <> "(the job might have completed or timed out)"
       LogPoll ->
         "Polling jobs table"
       LogWebUIRequest ->
@@ -320,6 +324,12 @@ defaultJsonLogEvent logEvent =
                    , "contents" Aeson..= (defaultJsonJob job, show e, defaultJsonFailureMode fm, runTime) ]
     LogJobTimeout job ->
       Aeson.object [ "tag" Aeson..= ("LogJobTimeout" :: Text)
+                   , "contents" Aeson..= defaultJsonJob job ]
+    LogKillJobSuccess job ->
+      Aeson.object [ "tag" Aeson..= ("LogKillJobSuccess" :: Text)
+                   , "contents" Aeson..= defaultJsonJob job ]
+    LogKillJobFailed job ->
+      Aeson.object [ "tag" Aeson..= ("LogKillJobFailed" :: Text)
                    , "contents" Aeson..= defaultJsonJob job ]
     LogPoll ->
       Aeson.object [ "tag" Aeson..= ("LogJobPoll" :: Text)]

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -22,7 +22,9 @@ createJobTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
   ", attempts int not null default 0" <>
   ", locked_at timestamp with time zone null" <>
   ", locked_by text null" <>
-  ", constraint incorrect_locking_info CHECK ((status <> 'locked' and locked_at is null and locked_by is null) or (status = 'locked' and locked_at is not null and locked_by is not null))" <>
+  ", constraint incorrect_locking_info CHECK (" <>
+    "(locked_at is null and locked_by is null and status <> 'locked') or " <>
+    "(locked_at is not null and locked_by is not null and (status = 'locked' or status = 'cancelled')))" <>
   ");" <>
   "create index if not exists ? on ?(created_at);" <>
   "create index if not exists ? on ?(updated_at);" <>


### PR DESCRIPTION
This adds the ability to kill a running job from the web UI, by adding an action to the menu for running jobs. When the "kill" button is clicked, the job is marked for cancellation and an asynchronous poller is responsible for reaping it later.

This adds a new status "Cancelled", which represents a job that has been manually killed and is either waiting to be reaped, or has been reaped and can be queued again.

To allow for cancelling job threads by ID, the internal runner now tracks job IDs alongside the spawned threads.

---

Fixes #31 . I noticed that issue and remembered that we had implemented it internally, so I thought it would be a good thing to upstream.