### PR TITLE
Use `hdaemonize`

### DIFF
--- a/ghc-9.2.5.stack.yaml
+++ b/ghc-9.2.5.stack.yaml
@@ -2,5 +2,4 @@ resolver: lts-20.3
 packages:
   - .
 extra-deps:
-  - daemons-0.3.0@sha256:356edaf06a8cf5e9f19685f9ce793ad6d2b6bce2e55379f6b2aff1b0c07a633f,3178
   - timing-convenience-0.1@sha256:7ff807a9a9e5596f2b18d45c5a01aefb91d4a98f6a1008d183b5c550f68f7cb7,2092

--- a/ghc-9.2.5.stack.yaml.lock
+++ b/ghc-9.2.5.stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: daemons-0.3.0@sha256:356edaf06a8cf5e9f19685f9ce793ad6d2b6bce2e55379f6b2aff1b0c07a633f,3178
-    pantry-tree:
-      sha256: 26b1a5279be340c896edbc72baa6d95b071384b9bf7e19cd146025cf13d21769
-      size: 918
-  original:
-    hackage: daemons-0.3.0@sha256:356edaf06a8cf5e9f19685f9ce793ad6d2b6bce2e55379f6b2aff1b0c07a633f,3178
-- completed:
     hackage: timing-convenience-0.1@sha256:7ff807a9a9e5596f2b18d45c5a01aefb91d4a98f6a1008d183b5c550f68f7cb7,2092
     pantry-tree:
       sha256: fbcb00f5b8a4f7b8fd94b034b7f507ffdd7579848de782ce60ad2b661dcb2b42

--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 81dabf5fa65d737ec98a4f07762968283cccc36292941ff7fff10a9a398e84b0
+-- hash: dff1ced317b40e54688799203ec3743b119bf71f2fc98109a5e79f12c6e10fba
 
 name:           odd-jobs
 version:        0.2.2
@@ -61,19 +61,27 @@ library
       Paths_odd_jobs
   hs-source-dirs:
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns
   build-depends:
       aeson
+    , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
-    , daemons
     , directory
     , either
     , fast-logger
     , filepath
     , friendly-time
     , generic-deriving
+    , hdaemonize
     , hostname
     , lucid
     , monad-control
@@ -81,7 +89,7 @@ library
     , mtl
     , optparse-applicative
     , postgresql-simple
-    , resource-pool >= 0.2.0.0 && < 0.4.0.0
+    , resource-pool
     , safe
     , servant
     , servant-lucid
@@ -115,13 +123,20 @@ executable devel
   hs-source-dirs:
       dev
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is DevelMain
   build-depends:
       aeson
+    , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
-    , daemons
     , directory
     , either
     , fast-logger
@@ -129,6 +144,7 @@ executable devel
     , foreign-store
     , friendly-time
     , generic-deriving
+    , hdaemonize
     , hostname
     , lucid
     , monad-control
@@ -162,19 +178,27 @@ executable odd-jobs-cli-example
       Paths_odd_jobs
   hs-source-dirs:
       examples
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is OddJobsCliExample
   build-depends:
       aeson
+    , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
-    , daemons
     , directory
     , either
     , fast-logger
     , filepath
     , friendly-time
     , generic-deriving
+    , hdaemonize
     , hostname
     , lucid
     , monad-control
@@ -219,20 +243,28 @@ test-suite jobrunner
   hs-source-dirs:
       test
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is Test
   build-depends:
       aeson
+    , async ==2.2.4
     , base >=4.7 && <5
     , bytestring
     , containers
-    , daemons
     , directory
     , either
     , fast-logger
     , filepath
     , friendly-time
     , generic-deriving
+    , hdaemonize
     , hedgehog
     , hostname
     , lifted-async

--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,8 @@ default-extensions:
 
 dependencies:
   - base >= 4.7 && < 5
+  - async ==2.2.4
+  - hdaemonize
   - text
   - postgresql-simple
   - bytestring
@@ -85,7 +87,6 @@ dependencies:
   - warp
   - unordered-containers
   - optparse-applicative
-  - daemons
   - filepath
   - directory
   - generic-deriving

--- a/src/OddJobs/Cli.hs
+++ b/src/OddJobs/Cli.hs
@@ -8,7 +8,6 @@ import Options.Applicative as Opts
 import Data.Text
 import OddJobs.Job (startJobRunner, Config(..), LogLevel(..), LogEvent(..))
 import OddJobs.Types (UIConfig(..), Seconds(..), delaySeconds)
--- import System.Daemonize (DaemonOptions(..), daemonize)
 import qualified System.Posix.Daemon as Daemon
 import System.FilePath (FilePath)
 import System.Posix.Process (getProcessID)
@@ -163,7 +162,6 @@ defaultStopCommand :: StopArgs
                    -> IO ()
 defaultStopCommand StopArgs{..} = do
   progName <- getProgName
-  -- pid <- read <$> (readFile shutPidFile)
   if shutTimeout == Seconds 0
     then Daemon.brutalKill shutPidFile
     else do putStrLn $ "Sending sigINT to " <> show progName <>
@@ -310,8 +308,6 @@ stopParser = fmap Stop $ StopArgs
   <$> option (Seconds <$> auto) ( long "timeout" <>
                                   metavar "TIMEOUT" <>
                                   help "Maximum seconds to wait before force-killing the background daemon."
-                                  -- value defaultTimeout <>
-                                  -- showDefaultWith (show . unSeconds)
                                 )
   <*> pidFileParser
 
@@ -343,16 +339,6 @@ defaultCliParserPrefs = prefs $
 defaultCliInfo :: CliType -> ParserInfo Args
 defaultCliInfo cliType =
   info (argParser cliType <**> helper) fullDesc
-
--- defaultDaemonOptions :: DaemonOptions
--- defaultDaemonOptions = DaemonOptions
---   { daemonShouldChangeDirectory = False
---   , daemonShouldCloseStandardStreams = False
---   , daemonShouldIgnoreSignals = True
---   , daemonUserToChangeTo = Nothing
---   , daemonGroupToChangeTo = Nothing
---   }
-
 
 -- ** Auth implementations for the default Web UI
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,4 @@ resolver: lts-20.3
 packages:
   - .
 extra-deps:
-  - daemons-0.3.0@sha256:356edaf06a8cf5e9f19685f9ce793ad6d2b6bce2e55379f6b2aff1b0c07a633f,3178
   - timing-convenience-0.1@sha256:7ff807a9a9e5596f2b18d45c5a01aefb91d4a98f6a1008d183b5c550f68f7cb7,2092


### PR DESCRIPTION
This PR replaces the use of the GPLv3 `daemons` library with `hdaemonize` to accommodate enterprise production environments. There are also a few minor deletions of previously commented out lines of code.