### PR TITLE
Qualify text imports to support ghc 9.10.2

### DIFF
--- a/src/OddJobs/Cli.hs
+++ b/src/OddJobs/Cli.hs
@@ -9,7 +9,8 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (newEmptyMVar, takeMVar, tryPutMVar, tryTakeMVar)
 import Data.Coerce (coerce)
 import Data.Functor (void)
-import Data.Text
+import qualified Data.Text as T
+import Data.Text (Text)
 import OddJobs.Job (startJobRunner, Config(..), LogLevel(..), LogEvent(..))
 import OddJobs.Types (UIConfig(..), Seconds(..), delaySeconds)
 import qualified System.Posix.Daemonize as Daemonize

--- a/src/OddJobs/Endpoints.hs
+++ b/src/OddJobs/Endpoints.hs
@@ -19,7 +19,8 @@ import Servant.HTML.Lucid
 import Lucid
 import Lucid.Html5
 import Lucid.Base
-import Data.Text as T
+import qualified Data.Text as T
+import Data.Text (Text)
 import Network.Wai.Handler.Warp   (run)
 import Servant.Server.StaticFiles (serveDirectoryFileServer)
 import UnliftIO hiding (Handler)

--- a/src/OddJobs/Job.hs
+++ b/src/OddJobs/Job.hs
@@ -85,7 +85,8 @@ where
 import OddJobs.Types
 import qualified Data.Pool as Pool
 import Data.Pool(Pool)
-import Data.Text as T
+import qualified Data.Text as T
+import Data.Text (Text)
 import Database.PostgreSQL.Simple as PGS
 import Database.PostgreSQL.Simple.Notification
 import UnliftIO.Async hiding (poll)


### PR DESCRIPTION
With latest ghc 9.10.2 both Prelude and Data.Text export the show function, causing a conflict if Data.Text is imported unqualified